### PR TITLE
Add Check for EntityTranslationDefinition

### DIFF
--- a/Framework/Api/Controller/ApiController.php
+++ b/Framework/Api/Controller/ApiController.php
@@ -776,7 +776,7 @@ class ApiController extends AbstractController
         if (\count($pathSegments) === 0) {
             $definition = $first['definition'];
             $events = $this->executeWriteOperation($definition, $payload, $context, $type);
-            $event = $events->getEventByEntityName($definition->getEntityName());
+            $event = $events->getEventByEntityName($definition->getEntityName() || $definition instanceof EntityTranslationDefinition);
             $eventIds = $event->getIds();
             $entityId = array_pop($eventIds);
 


### PR DESCRIPTION
ApiController Write Action was resulting in an Error, because a TranslationEntity was directly written.

Add Check for EntityTranslationDefinition if Entity is directly written an return an empty Response